### PR TITLE
Fix Google Analytics tracking by upgrading to GA4

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -90,16 +90,12 @@ $(document).ready(function() {
 {% endif %}
 
 {% if site.ga_tracking_id %}
-<!-- Google Analytics -->
+<!-- Google Analytics 4 -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking_id }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', '{{ site.ga_tracking_id }}', 'auto');
-  ga('send', 'pageview', {
-    'page': '{{ page.url }}',
-    'title': '{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}'
-  });
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.ga_tracking_id }}');
 </script>
 {% endif %}


### PR DESCRIPTION
- Updated Google Analytics implementation from Universal Analytics (GA3) to Google Analytics 4 (GA4)
- Replaced deprecated analytics.js with modern gtag.js Global Site Tag
- Fixed compatibility issue with GA4 tracking ID format (G-5NW8DYB40X)
- Universal Analytics was discontinued on July 1, 2023 and GA4 tracking IDs don't work with the old code

The site was configured with a GA4 tracking ID but was using outdated Universal Analytics code, preventing any visitor tracking. This change ensures proper analytics data collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)